### PR TITLE
新部署名に21文字以上入力された際に画面に警告文が出る機能実装。選択された登録済み部署名と新部署名が同じ時にエラー文を設定していたが、ボタ…

### DIFF
--- a/src/main/java/com/example/demo/service/DepartmentService.java
+++ b/src/main/java/com/example/demo/service/DepartmentService.java
@@ -18,40 +18,28 @@ public class DepartmentService {
 	
 		//ユーザー管理画面起動時の部署プルダウンに適用させる為、部署管理画面に部署を表示させる為に取得
 		public List<Department> departmentSearchListUp() {
-			List<Department> department = departmentMapper.selectDepartment();
-			return department;
+			return departmentMapper.selectDepartment();
 		}
 		
 		//部署管理画面の削除済み部署欄に表示させる為に取得
 		public List<Department> deleteDepartmentSearchListUp() {
-			List<Department> department = departmentMapper.selectDeleteDepartment();
-			return department;
+			return departmentMapper.selectDeleteDepartment();
 		}
-		
 		
 		//登録
 		public Integer departmentCheckInsert(DepartmentForm departmentForm) {
-			Integer overlappingDepartmentCheck = null;
-				overlappingDepartmentCheck = departmentMapper.insertDepartment(departmentForm);
-			return overlappingDepartmentCheck;
+			return departmentMapper.insertDepartment(departmentForm);
 		}
 		
-		//新名前と旧名前を比較後に名前変更
+		//旧名前を新名前に変更
 		public Integer departmentNameUpdate(DepartmentForm departmentForm) {
-			Integer overlappingDepartmentCheck = null;
-			if(!departmentForm.getNewDepartmentName().equals(departmentForm.getOldDepartmentName())) {
-				//0or1が返される。0はテーブルのデータに新部署名が存在したので変更していない。1はテーブルのデータに新部署名が存在しなかったので変更した。
-				overlappingDepartmentCheck = departmentMapper.updateDepartmentName(departmentForm);
-			}else {
-				//2は旧部署名と新部署名が全く一緒の時
-				overlappingDepartmentCheck = 2;
-			}
-			return overlappingDepartmentCheck;
+			//0or1が返される。0はテーブルのデータに新部署名が存在したので変更していない。1はテーブルのデータに新部署名が存在しなかったので変更した。
+			return departmentMapper.updateDepartmentName(departmentForm);
 		}
 		
 		//部署無効化（削除）更新
 		public void departmentDeactiveUpdate(DepartmentForm departmentForm) {
-				departmentMapper.updateDepartmentDeactive(departmentForm);
+			departmentMapper.updateDepartmentDeactive(departmentForm);
 		}
 		
 		//無効（削除済み）部署を有効化更新。

--- a/src/main/java/com/example/demo/service/ModelService.java
+++ b/src/main/java/com/example/demo/service/ModelService.java
@@ -29,10 +29,8 @@ public class ModelService {
 	public Model departmentNameUpdateModel(Integer departmentNameEqualCheck, RedirectAttributes redirectAttributes) {
 		if(departmentNameEqualCheck == 1) {
 			redirectAttributes.addFlashAttribute("departmentMessage", messageOutput.message("updateNameSuccess"));
-		}else if(departmentNameEqualCheck == 0){
-			redirectAttributes.addFlashAttribute("departmentErrorMessage", messageOutput.message("updateNameOverlapping"));
 		}else {
-			redirectAttributes.addFlashAttribute("departmentErrorMessage", messageOutput.message("updateNameSimilar"));
+			redirectAttributes.addFlashAttribute("departmentErrorMessage", messageOutput.message("updateNameOverlapping"));
 		}
 		return redirectAttributes;
 	}

--- a/src/main/java/com/example/demo/service/UserManagementService.java
+++ b/src/main/java/com/example/demo/service/UserManagementService.java
@@ -1,5 +1,7 @@
 package com.example.demo.service;
 
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -19,6 +21,7 @@ public class UserManagementService {
 	private final DepartmentService departmentService;
 	private final UserManagementFactory usersFactory;
 	private final UserManagementValidation userManagementValidation;
+	private final PasswordEncoder passwordEncoder;
 	
 	UserManagementService(UsersMapper userSearchMapper, MessageOutput messageOutput,DepartmentService departmentService,UserManagementFactory usersFactory,UserManagementValidation userManagementValidation){
 		this.userSearchMapper = userSearchMapper;
@@ -26,6 +29,7 @@ public class UserManagementService {
 		this.departmentService = departmentService;
 		this.usersFactory = usersFactory;
 		this.userManagementValidation = userManagementValidation;
+		this.passwordEncoder = new BCryptPasswordEncoder();
 	}
 	
 	/**
@@ -76,12 +80,13 @@ public class UserManagementService {
 	 * @return 処理結果を含む {@link Model} オブジェクト
 	 */
 	public Model dbActionchoice(ManagementForm managementForm, Model model) {
-			if ("9999/99/99".equals(managementForm.getStartDate().trim())) {
-				managementForm.setStartDate("9999-12-31");
-				userSearchMapper.userCreate(usersFactory.usersCreate(managementForm));
-			} else {
-				userSearchMapper.userCreate(usersFactory.usersCreate(managementForm));
-			}
+		managementForm.setPassword(passwordEncoder.encode(managementForm.getPassword()));
+		if ("9999/99/99".equals(managementForm.getStartDate().trim())) {
+			managementForm.setStartDate("9999-12-31");
+			userSearchMapper.userCreate(usersFactory.usersCreate(managementForm));
+		} else {
+			userSearchMapper.userCreate(usersFactory.usersCreate(managementForm));
+		}
 		return model.addAttribute("check", messageOutput.message("update", managementForm.getUserName()));
 	}
 	/**

--- a/src/main/resources/static/js/department.js
+++ b/src/main/resources/static/js/department.js
@@ -21,6 +21,14 @@ document.addEventListener("DOMContentLoaded", function() {
 		 const newDepartmentValue = checkNewDepartment.value.trim();
 		 const deletedDepartmentValue = checkDeletedDepartment.value.trim();
 		 
+		 // 文字数オーバーチェック
+		     if (newDepartmentValue.length > 20) {
+		         document.getElementById("error-message").innerHTML = "部署名は20文字以内で入力してください。";
+		         registrationButton.disabled = true;
+		         changeButton.disabled = true;
+		     } else {
+		         document.getElementById("error-message").innerHTML = "";
+		 
 		 //登録ボタン
 		 registrationButton.disabled = !(
 			oldDepartmentValue === "" &&
@@ -35,7 +43,7 @@ document.addEventListener("DOMContentLoaded", function() {
 			deletedDepartmentValue === "" &&
 			oldDepartmentValue !== newDepartmentValue
 		 );
-		 
+		 }
 		 //削除ボタン
 		 deleteButton.disabled = !(
 			oldDepartmentValue !== "" &&

--- a/src/main/resources/templates/department/department.html
+++ b/src/main/resources/templates/department/department.html
@@ -44,6 +44,7 @@
 							<label for="departmentAction">新部署名（登録/変更）</label>
 							<input type="text" class="form-control mb-3" id="departmentAction"
 								   name="newDepartmentName" placeholder="部署名を入力">
+							<p id="error-message" style="color: red;"></p>
 							<div class="d-grid gap-2">
 								<div>
 									<input type="submit" name="back" value="戻る"


### PR DESCRIPTION
…ンの非活性で対応したので不要になったので削除。ユーザー登録の際に入力されたパスワードを自動でハッシュ化してテーブルに登録する機能を実装。