### PR TITLE
CSSの調整

### DIFF
--- a/src/main/resources/static/CSS/create.css
+++ b/src/main/resources/static/CSS/create.css
@@ -10,6 +10,7 @@
 		margin-top: 60px;
 	}
 	
+	/*ヘッダー要素*/
 	.commonHeader {
 		position: fixed;
 		top: 0;
@@ -37,18 +38,7 @@
 		z-index: 1000; /* 他の要素より前面に表示 */
 	}
 	
-	.m-50 {
-		padding-top: 50px !important; /* 上に余白を追加 */
-		padding-bottom: 50px; /* 下に余白を追加 */
-		font-size: x-large !important;
-		/*    margin: 0 auto;*/
-	}
-	
-	.noneBox {
-		border: none;
-		width: 100%
-	}
-	
+	/*ボタン系レイアウト*/
 	.buttonSize {
 		width: 100px;
 		/*  border-radius: 40% 80% 35% 65% / 50% 50% 70% 40%;*/
@@ -61,36 +51,12 @@
 		background-color: yellow;
 		/*  border-radius:30px;*/
 	}
-	
-	.loginback {
-		text-align: right;
-	}
-	
-	.variableButtonSize {
-		/*	width: 100px;*/
-		display: inline-block;
-		padding: 10px 20px;
-		cursor: pointer;
-		background-color: yellow;
-		font-size: 20px;
-	}
-	
+	/*文字ボタン*/
 	.linklike {
 		border: none;
 		background-color: transparent;
 		color: blue;
 		text-decoration: underline;
-	}
-	
-	.menuButtonSize {
-		width: 260px;
-		height: 80px;
-	}
-	
-	.form-group {
-		display: flex;
-		flex-direction: column;
-		align-items: flex-start;
 	}
 	
 	.form-row {
@@ -103,68 +69,32 @@
 		width: 160px;
 	}
 	
-	.longLabel {
-		font-size: 24px;
-	}
-	
-	.loginFontsize {
-		font-size: 30px;
-	}
-	
-	.loginFontsize label {
-		display: inline-block;
-		width: 154px;
-	}
+	/*エラーメッセージ使っても使わなくても　text-dangerと合わせると色が濃くなります*/
 	
 	.error-message {
 		color: red;
 		font-weight: bold;
 	}
 	
-	.text-center {
-		text-align: center;
+	/*テーブル要素*/
+	.noneBox {
+		border: none;
+		width: 100%
 	}
 	
-	.highlight {
-		font-weight: bold;
-		color: black;
-	}
-	
-	.dim {
-		color: lightgray;
-	}
-	
-	.weatherInfo {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-	}
-	
-	.weatherInfo li {
-		justify-content: center; /* 水平方向の中央揃え */
-		margin-left: 10px;
-		margin-bottom: 10px; /* 各項目の間隔を調整 */
-	}
-	
-	.label {
-		width: 100px; /* ラベルの幅を固定 */
-		text-align: right; /* ラベルのテキストを右揃え */
-		margin-right: 10px; /* ラベルと値の間隔を調整 */
-	}
-	
-	.sticked {
+	.collapsedTable {
 			border-collapse: collapse;
 			border-spacing: 0;
 			width: 100%;
 		}
 		
-	.sticked tr th {
+	.collapsedTable tr th {
 		position: sticky;
 		top: 0px;
 		left: 0;
 	}
 
-	.sticked tr th::before {
+	.collapsedTable tr th::before {
 		content: "";
 		position: absolute;
 		top: -1px;
@@ -184,14 +114,7 @@
 			background-color: blueviolet;
 			/*  border-radius:30px;*/
 		}
-		.variableButtonSize {
-			/*	width: 100px;*/
-			display: inline-block;
-			padding: 10px 20px;
-			cursor: pointer;
-			background-color: yellow;
-			font-size: 20px;
-		}
+		
 	}
 }
 

--- a/src/main/resources/static/CSS/index.css
+++ b/src/main/resources/static/CSS/index.css
@@ -1,0 +1,45 @@
+@charset "UTF-8";
+
+	.indexContainer{
+		display: flex; /* フレックスボックスを使用 */
+	    justify-content: center; /* 水平方向に中央揃え */
+	    align-items: center; /* 垂直方向に中央揃え */
+	    margin: 0 auto; /* コンテナを中央に配置 */
+	}
+	
+	.indexBox{
+		padding:60px;
+	}
+	
+	.loginFontsize {
+		font-size: 30px;
+	}
+	
+	.loginFontsize label {
+		display: inline-block;
+		width: 154px;
+	}
+
+@media screen and (min-width: 481px) {
+	.variableButtonSize {
+			/*	width: 100px;*/
+			display: inline-block;
+			padding: 10px 20px;
+			cursor: pointer;
+			background-color: yellow;
+			font-size: 20px;
+		}
+		
+	
+	@media screen and (max-width: 480px) {
+		.variableButtonSize {
+					/*	width: 100px;*/
+					display: inline-block;
+					padding: 10px 20px;
+					cursor: pointer;
+					background-color: yellow;
+					font-size: 20px;
+				}
+	
+	}
+}

--- a/src/main/resources/static/CSS/management.css
+++ b/src/main/resources/static/CSS/management.css
@@ -1,0 +1,28 @@
+@charset "UTF-8";
+
+hr{
+	color:midnightblue;
+}
+@media screen and (min-width: 481px) {
+	
+	.m-50 {
+			padding: 50px 30px !important; /* 上に余白を追加 */;
+			font-size: x-large !important;
+			/*    margin: 0 auto;*/
+		}
+		
+	.buttonSize{
+		position: absolute;
+		top:0;
+		right:0; 
+		z-index:20 ;
+	}
+	
+	.error-message{
+		font-size: large;
+	}
+	
+	@media screen and (max-width: 480px) {
+	
+	}
+}

--- a/src/main/resources/static/CSS/monthlyAttendance.css
+++ b/src/main/resources/static/CSS/monthlyAttendance.css
@@ -67,6 +67,15 @@
 		text-align: center;
 		margin: 0 auto;
 	}
+	/*カレンダーコントロール周り ｊｓで使用 消さないで*/
+	.highlight {
+		font-weight: bold;
+		color: black;
+	}
+
+	.dim {
+		color: lightgray;
+	}
 
 	/*[ID]*/
 	#approve {

--- a/src/main/resources/static/CSS/processMenu.css
+++ b/src/main/resources/static/CSS/processMenu.css
@@ -1,0 +1,65 @@
+@charset "UTF-8";
+@media screen and (min-width: 481px) {
+	/*ボタン系*/
+	.menuButtonSize {
+		width: 260px;
+		height: 80px;
+	}
+	
+	.attendanceColor{
+		background-color: rgb(255, 128, 64);
+	}
+	
+	.dailyRepColor{
+		background-color: rgb(128, 128, 64);
+	}
+	
+	.departmentColor{
+		background-color: rgb(128, 255, 255);
+	}
+	
+	.managementColor{
+		background-color: rgb(131, 118, 137);
+	}
+	
+	.notFirstButton{
+		margin-top:15px;
+	}
+	/*天気系*/
+	.weatherContainer{
+		display: flex; 
+		justify-content: space-evenly;
+		background-color: #f0fff0; 
+		border-radius:.25rem; 
+		box-shadow: 1px 2px 1px #333;
+	}
+	
+	.weatherInfo {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.weatherInfo li {
+		justify-content: center; /* 水平方向の中央揃え */
+		margin-left: 10px;
+		margin-bottom: 10px; /* 各項目の間隔を調整 */
+	}
+	
+	.weatherColumn {
+		width: 100px; /* ラベルの幅を固定 */
+		text-align: right; /* ラベルのテキストを右揃え */
+		margin-right: 10px; /* ラベルと値の間隔を調整 */
+	}
+
+	
+	#mainForm{
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+	
+	@media screen and (max-width: 480px) {
+	
+	}
+}

--- a/src/main/resources/templates/Attendance/registration.html
+++ b/src/main/resources/templates/Attendance/registration.html
@@ -21,8 +21,8 @@
 							<input type="hidden" name="userId" th:value="${Users.userId}">
 						</div>
 						<div class="row">
-							<div class="text-danger" th:if="${check} != null">
-								<span th:text="${check}" style="color: red;"></span>
+							<div class="text-danger error-message" th:if="${check} != null">
+								<span th:text="${check}"></span>
 							</div>
 							<span class="col-4">
 								<div th:if="${Users.role} == 'Regular' or ${Users.role} == 'UnitManager'">
@@ -46,12 +46,12 @@
 									</th:block>
 								</span>
 							</span>
-							<div class="col-4" style="display:flex; justify-content:space-evenly;">
+							<div class="col-4 d-flex justify-content-evenly">
 								<div th:if="${Users.role} == 'Manager'">
 									<input type="submit" id="reject" value="却下" name="rejected"class="buttonSize" th:attr="role=${Users.role}" onclick="confirmSubmission(event)">
 									<input type="submit" id="approve" value="承認" name="approval"class="buttonSize"  th:attr="role=${Users.role}" onclick="confirmSubmission(event)">
-									<div class="text-danger" th:if="${choiceUsers} != null">
-										<span th:text="${choiceUsers}" style="color: red;"></span>
+									<div class="text-danger error-message" th:if="${choiceUsers} != null">
+										<span th:text="${choiceUsers}"></span>
 									</div>
 								</div>
 								<div th:unless="${Users.role} == 'Manager'">
@@ -103,8 +103,8 @@
 					<div th:if="${attendanceFormList} != null">
 						<div class="row m-2">
 							<div class="col-12 ml-3" >
-								<div class="text-danger" th:if="${attendanceMessage} != null">
-									<span th:text="${attendanceMessage}" style="color: red;"></span>
+								<div class="text-danger error-message" th:if="${attendanceMessage} != null">
+									<span th:text="${attendanceMessage}"></span>
 								</div>
 								<div class="text-danger">
 									<span th:if="${#fields.hasErrors('itemInaccurate')}" th:errors="*{itemInaccurate}"></span>

--- a/src/main/resources/templates/DailyReport/dailyReport.html
+++ b/src/main/resources/templates/DailyReport/dailyReport.html
@@ -106,7 +106,7 @@
 							<div th:if="${dailyReportForm} != null">
 								<div class="row m-2">
 									<div class="col-12 ml-5 DailyReportTable">
-										<table class="table table-bordered border border-dark sticked">
+										<table class="table table-bordered border border-dark collapsedTable">
 											<thead>
 												<tr>
 													<th th:if="${Users.role == 'Manager'}">提出者</th>
@@ -139,7 +139,7 @@
 																th:readonly="${Users.role == 'Manager'}"/>
 															<div th:if="${#fields.hasErrors('dailyReportDetailForm[__${start.index}__].dailyReportDetailTime')}"
 																th:errors="*{dailyReportDetailForm[__${start.index}__].dailyReportDetailTime}"
-																class="error-message"></div>
+																class="text-danger"></div>
 														</div>
 													</td>
 													<td>
@@ -151,7 +151,7 @@
 															th:readonly="${Users.role == 'Manager'}"/>
 														<div th:if="${#fields.hasErrors('dailyReportDetailForm[__${start.index}__].content')}"
 															th:errors="*{dailyReportDetailForm[__${start.index}__].content}"
-															class="error-message">
+															class="text-danger">
 														</div>
 													</td>
 												</tr>

--- a/src/main/resources/templates/Login/index.html
+++ b/src/main/resources/templates/Login/index.html
@@ -5,6 +5,7 @@
     <title>ログイン</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link th:href="@{/css/create.css}" rel="stylesheet" />
+	<link th:href="@{/css/index.css}" rel="stylesheet" />
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
    <meta name="viewport" content="width=device-width,initial-scale=1.0">
 </head>
@@ -15,8 +16,8 @@
 		</div>
 	</div>
 
-	<div class="container d-flex justify-content-center align-items-center vh-70 vw-70">
-		<div class="border border-dark" style="padding:90px;">
+	<div class="container indexContainer vh-70 vw-70">
+		<div class="border border-dark indexBox">
 			<form name="LoginForm" th:action="@{/login}" method="post">
 				<div class="loginFontsize">
 					<div class="form-row">
@@ -30,7 +31,7 @@
 					<div class="text-center">
 						<input type="submit" id="check" value="ログイン" class="buttonRound">
 					</div>
-					<div class="text-center" style="margin-top:12px;">
+					<div class="text-center mt-3">
 						<a th:href="@{/forgotpassword}">パスワードを忘れた方はこちら</a>
 					</div>
 				</div>

--- a/src/main/resources/templates/User/manegement.html
+++ b/src/main/resources/templates/User/manegement.html
@@ -1,87 +1,91 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset="UTF-8">
-    <title>ユーザー管理画面</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
-          crossorigin="anonymous">
-    <link th:href="@{/CSS/create.css}" rel="stylesheet"/>
+<meta charset="UTF-8">
+<title>ユーザー管理画面</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+      integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+      crossorigin="anonymous">
+<link th:href="@{/CSS/create.css}" rel="stylesheet"/>
+<link th:href="@{/CSS/management.css}" rel="stylesheet"/>
 </head>
 <body>
-    <div class="container d-flex align-items-center justify-content-center vh-100">
-        <div class="row">
-            <form th:action="@{/user/management}" name="managementForm" method="post">
-                <div align="right">
-                    <input type="submit" id="back" value="戻る" name="back" class="buttonSize">
-                </div>
-                <div class="m-50 border border-dark" style="padding:30px;">
-                    <div class="text-danger" th:if="${check} != null">
-                        <span th:text="${check}" style="color: red;"></span>
-                    </div>
-                    <div th:if="${managementForm} == null or ${managementForm} != null" th:object="${managementForm}" >
-                        <div class="text-danger">
-                            <span th:if="${#fields.hasErrors('userName')}" th:errors="*{userName}"></span>
-                        </div>
-                        <p>ユーザー名
-                            <input type="text" name="userName" th:value="${managementForm} != null ? *{userName} :''">
-                            <input type="submit" value="検索" name="search" class="buttonRound">
-                        </p>
-                        <hr style="color: midnightblue;">
-                        <div class="text-danger">
-                            <span th:if="${#fields.hasErrors('userId')}" th:errors="*{userId}"></span>
-                        </div>
-                        ユーザーID
-                        <span th:text="${managementForm} != null ? *{userId} : ''"></span>
-                        <input type="hidden" name="userId" th:value="${managementForm} != null ? *{userId} : ''">
-                        <div class="text-danger">
-                            <span th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></span>
-                        </div>
-                        <p>パスワード
-                            <input type="password" name="password" th:value="''">
-                        </p>
-                        <div class="text-danger">
-                            <span th:if="${#fields.hasErrors('role')}" th:errors="*{role}"></span>
-                        </div>
-						<div class="form-row">
-                            <label>権限</label>
-                            <select name="role" th:field="*{role}">
-                                <option value="" th:selected="*{role} == null">選択してください</option>
-                                <option value="UnitManager" th:selected="*{role} == 'UnitManager'">UnitManager</option>
-                                <option value="Manager" th:selected="*{role} == 'Manager'">Manager</option>
-                                <option value="Regular" th:selected="*{role} == 'Regular'">Regular</option>
-                                <option value="Admin" th:selected="*{role} == 'Admin'">Admin</option>
-                            </select>
+	<div class="container d-flex align-items-center justify-content-center vh-100">
+		<div class="row">
+			<form th:action="@{/user/management}" name="managementForm" method="post">
+				<div class="text-end">
+					<input type="submit" id="back" value="戻る" name="back" class="buttonSize">
+				</div>
+				<div class="m-50 border border-dark" >
+					<div class="text-danger error-message" th:if="${check} != null">
+						<span th:text="${check}"></span>
+					</div>
+					<div th:if="${managementForm} == null or ${managementForm} != null" th:object="${managementForm}" >
+						<div class="text-danger error-message">
+							<span th:if="${#fields.hasErrors('userName')}" th:errors="*{userName}"></span>
 						</div>
-                        <div class="text-danger">
-                            <span th:if="${#fields.hasErrors('department')}" th:errors="*{department}"></span>
-                        </div>
-                        <div class="form-row">
-                            <label>所属部署</label>
-                            <select id="department" name="departmentId">
-                                <option value="0" selected>選択してください</option>
-                                <option th:each="department : ${managementForm.department}"
-                                        th:value="${department.departmentId}"
-                                        th:text="${department.departmentName}"
-                                        th:selected="${department.departmentId} == ${managementForm.departmentId}">
-                                </option>
-                            </select>
-                        </div>
-						<div class="text-danger">
+						<p>ユーザー名
+							<input type="text" name="userName" th:value="${managementForm} != null ? *{userName} :''">
+							<input type="submit" value="検索" name="search" class="buttonRound">
+						</p>
+						<hr>
+						<div class="text-danger error-message">
+							<span th:if="${#fields.hasErrors('userId')}" th:errors="*{userId}"></span>
+						</div>
+						<div class="form-row">
+							<label>ユーザーID</label>
+							<span th:text="${managementForm} != null ? *{userId} : ''"></span>
+							<input type="hidden" name="userId" th:value="${managementForm} != null ? *{userId} : ''">
+						</div>
+						<div class="text-danger error-message">
+							<span th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></span>
+						</div>
+						<div class="form-row">
+							<label>パスワード</label>
+							<input type="password" name="password" th:value="''">
+						</div>
+						<div class="text-danger error-message">
+							<span th:if="${#fields.hasErrors('role')}" th:errors="*{role}"></span>
+						</div>
+						<div class="form-row">
+							<label>権限</label>
+							<select name="role" th:field="*{role}">
+								<option value="" th:selected="*{role} == null">選択してください</option>
+								<option value="UnitManager" th:selected="*{role} == 'UnitManager'">UnitManager</option>
+								<option value="Manager" th:selected="*{role} == 'Manager'">Manager</option>
+								<option value="Regular" th:selected="*{role} == 'Regular'">Regular</option>
+								<option value="Admin" th:selected="*{role} == 'Admin'">Admin</option>
+							</select>
+						</div>
+						<div class="text-danger error-message">
+							<span th:if="${#fields.hasErrors('department')}" th:errors="*{department}"></span>
+						</div>
+						<div class="form-row">
+							<label>所属部署</label>
+							<select id="department" name="departmentId">
+								<option value="0" selected>選択してください</option>
+								<option th:each="department : ${managementForm.department}"
+								    th:value="${department.departmentId}"
+								    th:text="${department.departmentName}"
+								    th:selected="${department.departmentId} == ${managementForm.departmentId}">
+								</option>
+							</select>
+						</div>
+						<div class="text-danger error-message">
 							<span th:if="${#fields.hasErrors('tel')}" th:errors="*{tel}"></span>
 						</div>
 						<div class="form-row">
 							<label>電話番号</label>
 							<input type="text" name="tel" th:value="${managementForm != null} ? *{tel} : ''">
 						</div>
-						<div class="text-danger">
+						<div class="text-danger error-message">
 							<span th:if="${#fields.hasErrors('address')}" th:errors="*{address}"></span>
 						</div>
 						<div class="form-row">
 							<label>メールアドレス</label>
 							<input type="text" name="address" th:value="${managementForm != null} ? *{address} : ''">
 						</div>
-						<div class="text-danger">
+						<div class="text-danger error-message">
 							<span th:if="${#fields.hasErrors('startDate')}" th:errors="*{startDate}"></span>
 						</div>
 						<div class="form-row">
@@ -89,14 +93,14 @@
 							<input type="text" name="startDate" th:value="${managementForm != null} ? *{startDate} : ''">
 						</div>
 						<div class="text-center">
-                    		<input type="submit" value="登録" name="insert" class="buttonRound">
+							<input type="submit" value="登録" name="insert" class="buttonRound">
 						</div>
-                    </div>
-                </div>
-            </form>   
-        </div>
-   	 </div>
-	 <script th:src="@{/js/common.js}"></script>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+					</div>
+				</div>
+			</form>   
+		</div>
+	 </div>
+	<script th:src="@{/js/common.js}"></script>
+	<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/changeforgot/changeforgotpassword.html
+++ b/src/main/resources/templates/changeforgot/changeforgotpassword.html
@@ -7,6 +7,7 @@
 		</title>
 		<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 		<link th:href="@{/css/create.css}" rel="stylesheet" />
+		<link th:href="@{/css/index.css}" rel="stylesheet" />
 		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 		<script>
 			th:src="@{/js/common.js}"
@@ -31,27 +32,26 @@
 			</div>
 		</div>
 		
-		<div class="loginback">
+		<div class="text-end">
 			<a th:href="@{/index}">
 				<input type="submit" id="logInBack" value="ログイン画面に戻る" name="loginBack" class="variableButtonSize">
 			</a>
 		</div>
 		
 		<div th:unless="${user} == null or ${user.tokenExpirationDateCheck} == 'false'">
-			
-			<div class="container d-flex justify-content-center align-items-center vh-100">
-				<div class="border border-dark" style="padding:90px;">
+			<div class="container vh-100 indexContainer">
+				<div class="border border-dark indexBox">
 					<form name="remakePass" th:action="@{/changeforgotpassword}" method="post">
 						<input type="hidden" name="userId" th:value="${user.userId}">
 						<input type="hidden" name="tokenExpiryDate" th:value="${#dates.format(user.tokenExpiryDate, 'yyyy-MM-dd HH:mm:ss')}">
 						
 						<div class="loginFontsize">
 							<div class="form-row">
-								<label class="longLabel">新しいパスワード</label>
+								<label class="fs-4">新しいパスワード</label>
 								<input type="password" id="newPassword" name="newPassword" class="m-3" oninput="checkInput(this)">
 							</div>
 							<div class="form-row">
-								<label class="longLabel">新しいパスワード<br>（確認用）</label>
+								<label class="fs-4">新しいパスワード<br>（確認用）</label>
 								<input type="password" id="checkNewPassword" name="checkNewPassword" class="m-3" oninput="checkInput(this)">
 							</div>
 							<div class="text-center">

--- a/src/main/resources/templates/department/department.html
+++ b/src/main/resources/templates/department/department.html
@@ -20,7 +20,7 @@
 			<form th:action="@{/department/action}" method="post">
 				<div class="row">
 					<div class="col-md-6">
-						<div class="form-group">
+						<div class="d-flex flex-column align-items-start">
 							<label for="activeDepartmentSelect" class="mb-2">登録済の部署</label>
 							<select class="form-control mb-5" id="activeDepartmentSelect" name="oldDepartmentName">
 								<option value="" selected></option>
@@ -40,11 +40,11 @@
 						</div>
 					</div>
 					<div class="col-md-6">
-						<div class="form-group">
+						<div class="d-flex flex-column align-items-start">
 							<label for="departmentAction">新部署名（登録/変更）</label>
 							<input type="text" class="form-control mb-3" id="departmentAction"
 								   name="newDepartmentName" placeholder="部署名を入力">
-							<p id="error-message" style="color: red;"></p>
+							<p id="error-message" class="text-danger"></p>
 							<div class="d-grid gap-2">
 								<div>
 									<input type="submit" name="back" value="戻る"

--- a/src/main/resources/templates/forgot/forgotpassword.html
+++ b/src/main/resources/templates/forgot/forgotpassword.html
@@ -5,8 +5,8 @@
     <title>パスワード忘れ</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link th:href="@{/css/create.css}" rel="stylesheet" />
+	<link th:href="@{/css/index.css}" rel="stylesheet" />
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-   <script th:src="@{/js/common.js}"></script>
    <meta name="viewport" content="width=device-width,initial-scale=1.0">
 </head>
 <body>
@@ -14,13 +14,13 @@
 		<p th:text="${emailSent}"></p>
 	</div>
 
-	<div class="loginback">
+	<div class="text-end mt-0">
 		<a th:href="@{/index}">
-		<input type="submit" id="logInBack" value="ログイン画面に戻る" name="logInBack" class="variableButtonSize">
+			<input type="submit" id="logInBack" value="ログイン画面に戻る" name="logInBack" class="variableButtonSize">
 		</a>
 	</div>
-	<div class="container d-flex justify-content-center align-items-center vh-100">
-		<div class="border border-dark" style="padding:90px;">
+	<div class="container vh-100 indexContainer">
+		<div class="border border-dark indexBox">
 			<form th:action="@{/forgotpassword(send=true)}" method="post">
 			   <div class="loginFontsize">
 			      <div class="form-row">
@@ -39,5 +39,6 @@
 			</div>
 		</div>
 	<script th:src="@{/js/forgotPassword.js}"></script>
+	<script th:src="@{/js/common.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/menu/processMenu.html
+++ b/src/main/resources/templates/menu/processMenu.html
@@ -7,13 +7,14 @@
 	rel="stylesheet"
 	integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" 
 	crossorigin="anonymous">
+<link th:href="@{/CSS/processMenu.css}" rel="stylesheet"/>
 <link th:href="@{/CSS/create.css}" rel="stylesheet" />
 
 </head>
 <body>
 	<div class="container" th:object="${Users}">
 		<div class="row"> 
-			<form id="mainForm" th:action="@{/logOff}" method="post" class="d-flex align-items-center justify-content-center commonHeader" >
+			<form id="mainForm" th:action="@{/logOff}" method="post" class="commonHeader" >
 				<div class="col-4 ">
 					ユーザー名: <span th:text="${Users.userName}"></span>
 					<input type="hidden" name="userName" th:value="${Users.userName}">
@@ -57,75 +58,58 @@
 <!--			    <img th:each="w : ${tomorrowWeather.weather}" th:src="@{'http://openweathermap.org/img/wn/' + ${w.icon} + '@2x.png'}" alt="天気アイコン">-->
 
 <!--				天気予報API無課金版-->
-				<div  style="display: flex; justify-content: space-evenly; background-color: #f0fff0; border-radius:.25rem; box-shadow: 1px 2px 1px #333;">
-					<ul class = "weatherInfo">
-						<h2>今日の天気</h2>
-						<li><span class = label>天気:</span> <span th:text="${weatherData.todayDescription}"></span></li>
-						<li><span class = label>気温:</span> <span th:text="${weatherData.todayTemp}"></span>°C</li>
-						<li><span class = label>湿度:</span> <span th:text="${weatherData.todayHumidity}"></span>%</li>
-						<li><span class = label>気圧:</span> <span th:text="${weatherData.todayPressure}"></span> hPa</li>
-					</ul>
-					<ul class="weatherInfo" >
-						<h2>明日の天気</h2>
-						<li><span class = label>天気:</span> <span th:text="${weatherData.tomorrowDescription}"></span></li>
-						<li><span class = label>気温:</span> <span th:text="${weatherData.tomorrowTemp}"></span>°C</li>
-						<li><span class = label>湿度:</span> <span th:text="${weatherData.tomorrowHumidity}"></span>%</li>
-						<li><span class = label>気圧:</span> <span th:text="${weatherData.tomorrowPressure}"></span> hPa</li>
-					</ul>
-				</div>
-			<div class="d-flex align-items-center justify-content-center " style="padding:50px;">		
+			<div  class = "weatherContainer">
+				<ul class = "weatherInfo">
+					<h2>今日の天気</h2>
+					<li><span class = "weatherColumn">天気:</span> <span th:text="${weatherData.todayDescription}"></span></li>
+					<li><span class = "weatherColumn">気温:</span> <span th:text="${weatherData.todayTemp}"></span>°C</li>
+					<li><span class = "weatherColumn">湿度:</span> <span th:text="${weatherData.todayHumidity}"></span>%</li>
+					<li><span class = "weatherColumn">気圧:</span> <span th:text="${weatherData.todayPressure}"></span> hPa</li>
+				</ul>
+				<ul class="weatherInfo" >
+					<h2>明日の天気</h2>
+					<li><span class = "weatherColumn">天気:</span> <span th:text="${weatherData.tomorrowDescription}"></span></li>
+					<li><span class = "weatherColumn">気温:</span> <span th:text="${weatherData.tomorrowTemp}"></span>°C</li>
+					<li><span class = "weatherColumn">湿度:</span> <span th:text="${weatherData.tomorrowHumidity}"></span>%</li>
+					<li><span class = "weatherColumn">気圧:</span> <span th:text="${weatherData.tomorrowPressure}"></span> hPa</li>
+				</ul>
+			</div>
+			<div class="d-flex align-items-center justify-content-center mt-2">		
 <!--					レギュラー＆ユニットマネージャー用-->
-					<div th:if="${Users.role=='Regular'||Users.role=='UnitManager'}">
-						<p>
-							<form th:action="@{/menu/index}" method="get">
-								<input type="submit" value="勤怠登録" class="menuButtonSize"
-									style="background-color: rgb(255, 128, 64);">
-							</form>
-							<!--						th:actionの修正予定"@{/menu/correction}"-->
-							<form th:action="@{/menu/correction}" method="get">
-								<input type="submit" value="勤怠修正" class="menuButtonSize"
-									style="background-color: rgb(255, 128, 64);margin-top:15px;" >
-							</form>
-						</p>
+				<div th:unless="${Users.role=='Admin'}">
+					<p>
+						<form th:action="@{/menu/index}" method="get">
+							<input type="submit" value="勤怠登録" class="menuButtonSize attendanceColor">
+						</form>
+						<form th:action="@{/menu/correction}" method="get">
+							<input type="submit" value="勤怠修正" class="menuButtonSize attendanceColor notFirstButton">
+						</form>
+					</p>
+					<p>
 						<form th:action="@{/menu/daily/detail}" method="get">
-							<input type="submit" value="日報登録" class="menuButtonSize"
-								style="background-color: rgb(128, 128, 64);">
+							<input type="submit" value="日報登録" class="menuButtonSize dailyRepColor">
 						</form>
-					</div>
-	
-<!--					管理者用-->
-					<div th:if="${Users.role=='Admin'}">
-<!--						ユーザー情報登録-->
-						<form th:action="@{/menu/usermanagement}" method="get">
-							<input type="submit" value="ユーザー情報登録" class="menuButtonSize"
-								style="background-color: rgb(131, 118, 137);">
-						</form>
-					</div>
-	
-<!--					マネージャー用-->
+					</p>
+					<!--					マネージャー用-->
 					<div th:if="${Users.role=='Manager'}">
 						<p>
-							<form th:action="@{/menu/index}" method="get">
-							<input type="submit" value="勤怠管理" class="menuButtonSize"
-								style="background-color: rgb(255, 128, 64);">
-							</form>
-							<form th:action="@{/menu/correction}" method="get">
-								<input type="submit" value="勤怠修正" class="menuButtonSize"
-									style="background-color: rgb(255, 128, 64);margin-top:15px;" >
+							<form th:action="@{/menu/department}" method="get">
+								<input type="submit" value="部署登録" class="menuButtonSize departmentColor">
 							</form>
 						</p>
-						<p>
-							<form th:action="@{/menu/daily/detail}" method="get">
-								<input type="submit" value="日報管理" class="menuButtonSize"
-									style="background-color: rgb(128, 128, 64);">
-							</form>
-						</p>
-						<form th:action="@{/menu/department}" method="get">
-							<input type="submit" value="部署登録" class="menuButtonSize"
-								style="background-color: rgb(128, 255, 255);">
-						</form>
+					</div>
 				</div>
-			</p>
+	
+<!--					管理者用-->
+				<div th:if="${Users.role=='Admin'}">
+<!--						ユーザー情報登録-->
+					<p>
+						<form th:action="@{/menu/usermanagement}" method="get">
+							<input type="submit" value="ユーザー情報登録" class="menuButtonSize managementColor">
+						</form>
+					</p>
+				</div>
+			</div>
 		</div>
 	</div>
 	<script th:src="@{/js/common.js}"></script>

--- a/src/main/resources/templates/monthlyAttendanceReq/monthlyAttendance.html
+++ b/src/main/resources/templates/monthlyAttendanceReq/monthlyAttendance.html
@@ -75,15 +75,10 @@
 									<div class="col-2"></div>
 								</div>
 							</div>
-							<div class="row m-5" ></div><div class="row m-3" ></div>
-							<div class="row m-4" >
-								<div class="col-6"></div>
-								
-								
-							</div>
+							<div class="row m-5" ></div>
 							<div class="row m-4">
-								<span class="col-xl-6" style="margin-top:40px;">
-									<div th:if="${HasChangeReq} != null" style="margin-top:auto;"><!--マネージャー画面でない限りnull-->
+								<span class="col-xl-6 mt-5">
+									<div th:if="${HasChangeReq} != null" class="mt-auto;"><!--マネージャー画面でない限りnull-->
 										<table class="table table-bordered border border-dark " id="attendanceList">
 											<thead>
 												<tr>
@@ -142,8 +137,8 @@
 									</span>
 								</div>
 								<div class="row m-1">
-									<div class="text-danger" th:if="${check} != null">
-										<span th:text="${check}" style="color: red;"></span>
+									<div class="text-danger error-message" th:if="${check} != null">
+										<span th:text="${check}"></span>
 									</div>
 								</div>
 							</div>
@@ -151,7 +146,7 @@
 							<div th:if="${attendanceFormList} != null">
 								<div class="row">
 									<div class="attendanceList">
-										<table class="table table-bordered border border-dark sticked">
+										<table class="table table-bordered border border-dark collapsedTable">
 											<thead>
 												<tr>
 													<th>日付</th>


### PR DESCRIPTION
新規に個別画面のcssファイルを作成
似たようなレイアウトのログインやパスワード変更系のページはおなじcssを適用しています
ほとんど共通で使っているものをcreateに残し、特定のページでしか使っていないものを個別のcssに分けています。
レスポンシブ対応地味にできないところがあると思うので、修正予定です。
またscss導入ができれば個別cssで消えるものがあると思います。