### PR TITLE
バグ修正、アラートアプデ

### DIFF
--- a/src/main/java/com/example/demo/mapper/DailyReportMapper.java
+++ b/src/main/java/com/example/demo/mapper/DailyReportMapper.java
@@ -27,7 +27,7 @@ public interface DailyReportMapper {
 	public void updateConfirmDailyReport(DailyReportForm dailyReportForm);
 	
 	//昨日の日報存在確認
-	public Integer selectYesterdayCheck(Integer userId, LocalDate yesterday);
+	public List<String> selectYesterdayCheck(Integer userId, LocalDate yesterday,LocalDate oneWeekAgoDate);
 	
 	//確認待ちユーザー情報の取得
 	public List<DailyReportForm> selectConfirmPending(@Param("dailyReportDate")String dailyReportDate);

--- a/src/main/java/com/example/demo/service/CommonActivityService.java
+++ b/src/main/java/com/example/demo/service/CommonActivityService.java
@@ -62,11 +62,12 @@ public class CommonActivityService {
 			//メソッドの位置をそれぞれ変えたほうがいい。あるいはヘルパークラスを作成してそこに入れる
 			LocalDate today = LocalDate.now();
 			LocalDate yesterday = today.minusDays(1);
-			Integer checkDailyReport = dailyReportService.checkYesterdayDailyReport(users.getUserId(), yesterday);
+			String checkDailyReport = dailyReportService.checkYesterdayDailyReport(users.getUserId(), yesterday);
 			Integer checkAttendance = attendanceManagementService.checkYesterdayAttendance(users.getUserId(),
 					yesterday);
-			if (checkDailyReport == 0) {
+			if (checkDailyReport != null) {
 				model.addAttribute("CheckDailyReport", messageOutput.message("checkDailyReport"));
+				model.addAttribute("MissingSubmitDReport",checkDailyReport);
 			}
 			if (checkAttendance == 0) {
 				model.addAttribute("CheckAttendance", messageOutput.message("checkAttendance"));

--- a/src/main/java/com/example/demo/service/DailyReportService.java
+++ b/src/main/java/com/example/demo/service/DailyReportService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
@@ -25,8 +26,11 @@ public class DailyReportService {
 	private DailyReportDetailMapper dailyReportDetailMapper;
 
 	//昨日の日報のステータス取得
-	public Integer checkYesterdayDailyReport(Integer userId, LocalDate yesterday) {
-		Integer checkDailyReport = dailyReportMapper.selectYesterdayCheck(userId, yesterday);
+	public String checkYesterdayDailyReport(Integer userId, LocalDate yesterday) {
+		LocalDate oneWeekAgoDate = yesterday.minusDays(7);
+		List<String> listCheckDailyReport = dailyReportMapper.selectYesterdayCheck(userId, yesterday,oneWeekAgoDate);
+		String checkDailyReport = listCheckDailyReport.stream().collect(Collectors.joining(", "));
+		System.out.println(checkDailyReport);
 		return checkDailyReport;
 	}
 	

--- a/src/main/resources/com/example/demo/mapper/DailyReportMapper.xml
+++ b/src/main/resources/com/example/demo/mapper/DailyReportMapper.xml
@@ -12,11 +12,38 @@
 	and daily_report_date = #{dailyReportDate}
 </select>
 
-<!--昨日の日報が出ているかを確認する -->
-<select id="selectYesterdayCheck" resultType="int">
-	SELECT EXISTS (SELECT 1 FROM daily_report WHERE
-	user_id = #{userId} 
-	AND daily_report_date = #{yesterday});
+<!--昨日から一週間分の日報が出ているかを確認する -->
+<select id="selectYesterdayCheck" >
+<!--再起CTE 前日から一週間前までのカレンダーを作成-->
+WITH RECURSIVE DateRange AS (
+    SELECT #{oneWeekAgoDate} AS date
+    UNION ALL
+    SELECT DATE_ADD(date, INTERVAL 1 DAY)
+    FROM DateRange
+    WHERE DATE_ADD(date, INTERVAL 1 DAY) &lt;= #{yesterday}
+)
+SELECT 
+     DATE_FORMAT(dr.date, '%Y-%m-%d') AS date
+FROM 
+    DateRange dr
+LEFT JOIN 
+    kinntaikannri.attendance a 
+ON 
+    dr.date = a.attendance_date
+AND 
+    a.user_id = #{userId}
+LEFT JOIN 
+    kinntaikannri.daily_report d 
+ON 
+    dr.date = d.daily_report_date
+AND 
+    d.user_id = #{userId}
+WHERE 
+    (d.status IS NULL)
+    AND (a.status IS NULL OR a.status NOT IN (1, 2, 4, 5, 9, 11));
+<!--	SELECT EXISTS (SELECT 1 FROM daily_report WHERE-->
+<!--	user_id = #{userId} -->
+<!--	AND daily_report_date = #{yesterday});-->
 </select>
 
 <!--確認待ちユーザー取得-->

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -61,7 +61,7 @@ notEntered = 勤怠の入力を行ってください。
 choiceUsers = 先にユーザーを選択してください。
 attendanceSuccess = 勤怠を登録しました。
 #昨日の提出状況の把握
-checkDailyReport = "日報未提出"
+checkDailyReport = 日報未提出一覧: 
 checkAttendance = "勤怠未提出"
 monthlyAttendanceStatusIsThree = "先月の月次勤怠申請が却下されています。"
 monthlyAttendanceStatusIsSent="先月の月次勤怠申請が届いています。"

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -6,14 +6,15 @@
         history.pushState(null, null, location.href);
     };
 })();
-//ボタン連打防止機能　懸念点常に二重送信になっているのでは？という可能性はある。可能性だけ
-function disableSubmit(button){
-	//ボタンを無効化
-	 button.disabled = true;
-	 //ボタンに紐づいたform送信
-	 button.form.submit();
-	 //5秒後にボタン有効化・5秒はパスワードリセットのメール送信ボタンにマージンを取った値
-	    setTimeout(function() {
-	        button.disabled = false;
-	    }, 5000);
-	}
+
+	document.querySelectorAll('input[type="submit"]').forEach(function(button) {
+		button.addEventListener('mouseup', function(event) {
+		            // ボタンから手を離したときにボタンを無効化
+		            setTimeout(function() {
+		                button.disabled = true;
+		                setTimeout(function() {
+		                    button.disabled = false; // 5秒後にボタンを有効化
+		                }, 5000);
+		            }, 0); // フォーム送信後にボタンを無効化
+		        });
+		    });

--- a/src/main/resources/templates/Attendance/registration.html
+++ b/src/main/resources/templates/Attendance/registration.html
@@ -60,7 +60,7 @@
 									</span>
 									<span>
 										<input type="submit" id="register" value="登録" name="insert" class="buttonSize"
-											th:attr="disabled=${Users.status} != 3 and ${Users.status} != 0" onclick="disableSubmit(this)">
+											th:attr="disabled=${Users.status} != 3 and ${Users.status} != 0">
 									</span>
 								</div>
 							</div>

--- a/src/main/resources/templates/Login/index.html
+++ b/src/main/resources/templates/Login/index.html
@@ -31,7 +31,7 @@
 								<input type="password" id="userName" name="password" class="m-3 col-7" autocomplete="off">
 							</div>
 							<div class="text-center">
-								<input type="submit" id="check" value="ログイン" class="buttonRound"  onclick="disableSubmit(this)">
+								<input type="submit" id="check" value="ログイン" class="buttonRound">
 							</div>
 							<div class="text-center mt-3">
 								<a th:href="@{/forgotpassword}">パスワードを忘れた方はこちら</a>

--- a/src/main/resources/templates/menu/processMenu.html
+++ b/src/main/resources/templates/menu/processMenu.html
@@ -43,7 +43,7 @@
 				</div>
 				<div th:if="${CheckDailyReport}"  role="alert">
 					<i class="fa-solid fa-circle-exclamation"></i>
-					<p class="mb-0" th:text="${CheckDailyReport}"></p>
+					<p class="mb-0" th:text="${CheckDailyReport}+ ''+ ${MissingSubmitDReport}"></p>
 				</div>
 				<div th:if="${monthlyAttendanceStatusIsThree}"  role="alert">
 					<i class="fa-solid fa-bell"></i>

--- a/src/main/resources/templates/monthlyAttendanceReq/monthlyAttendance.html
+++ b/src/main/resources/templates/monthlyAttendanceReq/monthlyAttendance.html
@@ -57,11 +57,11 @@
 								</div>	
 								<div class="col">
 									<div th:unless="${Users.role=='Manager'}">
-										<input type="submit" id="willCorrect" value="訂正申請" name="willCorrect" class="buttonSize" disabled  onclick="disableSubmit(this)">
+										<input type="submit" id="willCorrect" value="訂正申請" name="willCorrect" class="buttonSize" disabled>
 									</div>
 									<div th:if="${Users.role=='Manager'}">
-										<input type="submit" id="approve" value="承認" name="approval"class="buttonSize" th:attr="disabled=${attendanceFormList == null}"  onclick="disableSubmit(this)">
-										<input type="submit" id="reject" value="却下" name="rejected"class="buttonSize"  disabled  onclick="disableSubmit(this)">
+										<input type="submit" id="approve" value="承認" name="approval"class="buttonSize" th:attr="disabled=${attendanceFormList == null}">
+										<input type="submit" id="reject" value="却下" name="rejected"class="buttonSize"  disabled  >
 									</div>
 								</div>
 							</div>
@@ -211,7 +211,7 @@
 			    /*]]>*/
 			</script>
 			<script th:src="@{/js/monthlyAttendance.js}" defer></script>
-			<script th:src="@{/js/common.js}" async></script>
+			<script th:src="@{/js/common.js}"></script>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
DailyReportMapper.java/日報存在確認メソッドの方をList<String>型に変更
commonActivityService.java/65行目日報確認用変数をString型に変更、条件分岐をそれに伴い変更。新たなモデルを追加。
dailyReportService.java/日報確認メソッドをアップデート。細かくはxmlのほうに書くが、直近一週間を見て未提出があれば、そのリストを返すように。
dailyReportMapper.xml/大幅に変更。resulttypeはintではなくリストになったので削除。再起CTEなるものを追加。一時的に使用できる仮組のSQL
昨日から一週間前をdateとしてdateから昨日までの日付範囲をSQLテーブルとして生成するもの。
そのテーブルを使用して勤怠管理が出ていて日報が出ていない、または両者出ていない日付を昨日から一週間前まで確認して、該当するものを返すSQL文に変更
また出ていなくとも勤怠管理が休日に該当している場合は日報を要求しなくなりました。
messageproperty/文言を変更
common.js/ボタン連打防止用のメソッドを削除して新たなものに変更。これにより、input type=submitはすべてページがリロードされるか五秒経過するまで連打できなくなりました。
html(disableSubmit()関係あるやつ)/ボタンメソッドのonclickが削除
processMenu.html/日報関係の仕様変更により、日報アラートにモデルを追加