### PR TITLE
エラー取りとダークモード機能の拡張

### DIFF
--- a/src/main/resources/static/CSS/styles.css
+++ b/src/main/resources/static/CSS/styles.css
@@ -8585,7 +8585,7 @@ input[type=time]::-webkit-calendar-picker-indicator {
   padding: 10px 20px;
   cursor: pointer;
   background-color: #ffc107;
-  font-size: 20px;
+  font-size: 16px;
 }
 
 hr {

--- a/src/main/resources/static/js/Report.js
+++ b/src/main/resources/static/js/Report.js
@@ -4,8 +4,13 @@ const content = Array.from(document.querySelectorAll('input[name^="dailyReportDe
 
 $(document).ready(function() {
     $('#today').change(function() {
+		if($('#today').val()!==''){
         // フォームを自動的に送信
         $('#dateSubmit').click();
+		}else{
+		setTodayDate();
+		$('#dateSubmit').click();
+		}
     });
 });
  

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -42,6 +42,14 @@ document.querySelectorAll('input[type="submit"]').forEach(function(button) {
 
 //読み込み時起動
 document.addEventListener('DOMContentLoaded',() =>{	
+	
+	//各ページにfontAwesomeのスタイルシート読み込みを張るjs
+	const link = document.createElement('link');
+	  link.rel = 'stylesheet';
+	  link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css';
+	  // ヘッダーにスタイルシートを追加
+	  document.head.appendChild(link);
+	  
 	//darkmode機能
 	const changeButton = document.getElementById('theme-change');
 	const htmlElement = document.documentElement;//＜html＞要素を指すためページ全体のレイアウトを操作
@@ -53,11 +61,13 @@ document.addEventListener('DOMContentLoaded',() =>{
 		localStorage.setItem('theme',savedTheme);//"light"をローカルストレージに格納…jsのローカルストレージはウェブブラウザにデータを保存します。ブラウザ再起動後も保持
 	}
 	htmlElement.setAttribute('data-bs-theme',savedTheme);//savedThemeをdata-bs-themeに適用
+	changeButton.innerHTML  = savedTheme === 'light' ? '<i class="fas fa-moon"></i>' : '<i class="fa-solid fa-sun"></i>';
 		
 	//changeButton押下後起動
 	changeButton.addEventListener('click',() => {
 		const currentTheme = htmlElement.getAttribute('data-bs-theme');
 		const newTheme = currentTheme === 'light' ? 'dark' :'light';//currentThemeがlightならdark（?以下True時）darkならlight(:以下False時)
+		changeButton.innerHTML  = newTheme === 'light' ? '<i class="fas fa-moon"></i>' : '<i class="fa-solid fa-sun"></i>';
 	
 		htmlElement.setAttribute('data-bs-theme',newTheme);//mode切り替え
 		localStorage.setItem('theme',newTheme);//modeを保存

--- a/src/main/resources/static/scss/styles.scss
+++ b/src/main/resources/static/scss/styles.scss
@@ -368,7 +368,7 @@ input[type='time'] {
 				padding: 10px 20px;
 				cursor: pointer;
 				@include bg-color($yellow);
-				font-size: 20px;
+				font-size: 16px;
 			}
 
 	

--- a/src/main/resources/templates/Login/index.html
+++ b/src/main/resources/templates/Login/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <title>ログイン</title>
 	<link th:href="@{/css/styles.css}" rel="stylesheet"/>
-    <link th:href="@{/css/create.css}" rel="stylesheet" />
-	<link th:href="@{/css/index.css}" rel="stylesheet" />
 <!--    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>-->
    <meta name="viewport" content="width=device-width,initial-scale=1.0">
 </head>
@@ -15,6 +13,20 @@
 			<span th:text="${session.SPRING_SECURITY_LAST_EXCEPTION?.message ?: 'ユーザー情報が存在しません'}"></span>
 		</div>
 	</div>
+	<header>
+	    <div class="row d-flex justify-content-evenly">
+	        <div class="col-3">
+	            <button id="theme-change" class="btn btn-sm btn-primary" type="button"></button>
+	        </div>
+	        <div class="col-3 mt-1">
+	        </div>
+	        <div class="col-3 mt-1">
+	        </div>
+	        <div class="col-3">
+	        </div>
+	    </div>
+	</header>
+	
 	
 	<div class="indexContainer">
 		<div class="row">

--- a/src/main/resources/templates/changeforgot/changeforgotpassword.html
+++ b/src/main/resources/templates/changeforgot/changeforgotpassword.html
@@ -6,7 +6,7 @@
 			パスワード変更
 		</title>
 		<link th:href="@{/css/styles.css}" rel="stylesheet"/>
-		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<!--		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>-->
 		<meta name="viewport" content="width=device-width,initial-scale=1.0">
 	</head>
 	
@@ -28,11 +28,22 @@
 			</div>
 		</div>
 		
-		<div class="text-end">
-			<a th:href="@{/index}">
-				<input type="submit" id="logInBack" value="ログイン画面に戻る" name="loginBack" class="variableButtonSize">
-			</a>
-		</div>
+		<header>
+		    <div class="row d-flex justify-content-evenly">
+		        <div class="col-3">
+		            <button id="theme-change" class="btn btn-sm btn-primary" type="button"></button>
+		        </div>
+		        <div class="col-3 mt-1">
+		        </div>
+		        <div class="col-3 mt-1">
+		        </div>
+		        <div class="col-3 text-end">
+					<a th:href="@{/index}">
+						<input type="submit" id="logInBack" value="ログイン画面に戻る" name="logInBack" class="variableButtonSize">
+					</a>
+		        </div>
+		    </div>
+		</header>
 		
 		<div th:unless="${user} == null or ${user.tokenExpirationDateCheck} == 'false'">
 			<div class="indexContainer">

--- a/src/main/resources/templates/common/commonHeader.html
+++ b/src/main/resources/templates/common/commonHeader.html
@@ -2,7 +2,6 @@
 <html xmlns:th="http://www.thymeleaf.org">
 	<head>
 		<meta charset="UTF-8">
-		<title>月次勤怠変更処理</title>
 		<link th:href="@{/css/styles.css}" rel="stylesheet"/>
 	</head>
 	<body>
@@ -12,7 +11,7 @@
 				    <div class="commonHeader">
 				        <div class="row d-flex justify-content-evenly">
 				            <div class="col-3">
-				                <button id="theme-change" class="btn btn-sm btn-primary" type="button">テーマ変更</button>
+				                <button id="theme-change" class="btn btn-sm btn-primary" type="button"></button>
 				            </div>
 				            <div class="col-3 mt-1">
 				                ユーザー名:<span th:text="${Users.userName}"></span>
@@ -33,7 +32,7 @@
 				    <div class="commonHeader">
 				        <div class="row d-flex justify-content-evenly">
 				            <div class="col-3">
-				                <button id="theme-change" class="btn btn-sm btn-primary" type="button">テーマ変更</button>
+				                <button id="theme-change" class="btn btn-sm btn-primary" type="button"></button>
 				            </div>
 				            <div class="col-3 mt-1">
 				                ユーザー名:<span th:text="${Users.userName}"></span>

--- a/src/main/resources/templates/forgot/forgotpassword.html
+++ b/src/main/resources/templates/forgot/forgotpassword.html
@@ -4,19 +4,30 @@
     <meta charset="UTF-8">
     <title>パスワード忘れ</title>
 	<link th:href="@{/css/styles.css}" rel="stylesheet"/>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<!--    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>-->
    <meta name="viewport" content="width=device-width,initial-scale=1.0">
 </head>
 <body  class="p-0">
 	<div class="alert alert-success text-center" th:if="${emailSent}">
 		<p th:text="${emailSent}"></p>
 	</div>
+	<header>
+	    <div class="row d-flex justify-content-evenly">
+	        <div class="col-3">
+	            <button id="theme-change" class="btn btn-sm btn-primary" type="button"></button>
+	        </div>
+	        <div class="col-3 mt-1">
+	        </div>
+	        <div class="col-3 mt-1">
+	        </div>
+	        <div class="col-3 text-end">
+				<a th:href="@{/index}">
+					<input type="submit" id="logInBack" value="ログイン画面に戻る" name="logInBack" class="variableButtonSize">
+				</a>
+	        </div>
+	    </div>
+	</header>
 
-	<div class="text-end mt-0">
-		<a th:href="@{/index}">
-			<input type="submit" id="logInBack" value="ログイン画面に戻る" name="logInBack" class="variableButtonSize">
-		</a>
-	</div>
 	<div class="indexContainer">
 		<div class="indexBox">
 			<form th:action="@{/forgotpassword(send=true)}" method="post">

--- a/src/main/resources/templates/menu/processMenu.html
+++ b/src/main/resources/templates/menu/processMenu.html
@@ -4,7 +4,6 @@
 <meta charset="UTF-8">
 <title>処理メニュー</title>
 <link th:href="@{/css/styles.css}" rel="stylesheet"/>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
 </head>
 <body>


### PR DESCRIPTION
report.js/日付変更フォームを削除したところエラーを吐いたので、日付欄がnullの時の処理を追加し対応
common.js/各ページにfontAwesomeのリンクを追加するjsを作成。保守的にありかと思い、実験中。またダークモード切替ボタンのアイコンをモードごとに切り替わるように
scss/パス忘れ系のフォントサイズを少々変更
index.html/ヘッダー？を追加。ダークモード切替ボタン配置用共通化なし。
パス忘れ系HTML/同上。ログインバックもヘッダーに配置するように。上記共にアラートのほうが上にくるようになっているが仕様。後で変更する可能性あり。
processMenu.html/fontAwesomeのリンクをjsで追加しているため、こちらを削除。
commonheader.html/titleを消去。テーマ変更の記述を消去。
